### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Model Context Protocol server for Obsidian vault integration. This allows Claude Desktop (or any MCP client) to search and read your Obsidian notes.
 
+<a href="https://glama.ai/mcp/servers/sed8z2tqq9"><img width="380" height="200" src="https://glama.ai/mcp/servers/sed8z2tqq9/badge" alt="@kazuph/mcp-obsidian MCP server" /></a>
+
 ## Quick Start (For Users)
 
 ### Prerequisites


### PR DESCRIPTION
This PR adds a badge for the @kazuph/mcp-obsidian server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/sed8z2tqq9"><img width="380" height="200" src="https://glama.ai/mcp/servers/sed8z2tqq9/badge" alt="@kazuph/mcp-obsidian MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.